### PR TITLE
Fixes Ubuntu/Debian installation commands

### DIFF
--- a/_includes/index/releases.html
+++ b/_includes/index/releases.html
@@ -22,8 +22,7 @@
             </p>
 
             <p id="ubuntu-ppa"></p>
-            <code>sudo dpkg -i packagename.deb</code> or just double click.<br>
-            If <code>dpkg</code> reports an error due to dependency problems, run <code>sudo apt-get install -f</code>. <br>
+            <code>sudo apt install ./packagename.deb</code> or just double click.<br>
         </li>
         <li class="distro-icon distro-archlinux">
             <p>


### PR DESCRIPTION
Usind "apt install" command instead of "dpkg -i and apt install -f", because
```sudo apt install ./packagename.deb```
manages the dependencies. 