### PR TITLE
Tweak logic for determining is a release is stable

### DIFF
--- a/assets/js/releases.js
+++ b/assets/js/releases.js
@@ -101,8 +101,8 @@ jQuery(function($) {
         for (var i = 0; i < data.length; i++) {
             var item = data[i];
             var assets = getAssets(item);
-            var isStable = item.name.indexOf('beta') === -1 && item.name.indexOf(' ') === -1;
-            if (!item.prerelease && assets && !item.draft && ((stable && isStable) || (!stable && !isStable))) {
+            var isStable = /^\d+\.\d+\.\d+$/.test(item.tag_name) && !item.prerelease;
+            if (assets && !item.draft && stable === isStable) {
                 return {
                     name: item.name,
                     tag_name: item.tag_name,

--- a/assets/js/releases.js
+++ b/assets/js/releases.js
@@ -101,7 +101,7 @@ jQuery(function($) {
         for (var i = 0; i < data.length; i++) {
             var item = data[i];
             var assets = getAssets(item);
-            var isStable = /^\d+\.\d+\.\d+$/.test(item.tag_name) && !item.prerelease;
+            var isStable = /^\d+\.\d+\.\d+$/.test(item.name || item.tag_name) && !item.prerelease;
             if (assets && !item.draft && stable === isStable) {
                 return {
                     name: item.name,


### PR DESCRIPTION
* Change validation so only releases with a tags like "1.2.3" are considered stable, and the rest are unstable
* Count pre-releases as unstable releases (if they have assets)
* Use `name` with fallback to `tag_name` for the regex, since `name` can be missing, and `tag_name` shouldn't be, but only `name` can be edited post-release.