### PR TITLE
Add a nav link to docs

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -3,6 +3,7 @@
 	<nav id="nav">
 		<ul>
 			<li><a href="/#Download">Download</a></li>
+			<li><a href="https://docs.ulauncher.io">Docs</a></li>
 			<li><a href="https://ext.ulauncher.io">Extensions</a></li>
 			<li><a href="https://gist.github.com/gornostal/02a232e6e560da7946c053555ced6cce">Color Themes</a></li>
 			<li><a href="https://github.com/Ulauncher/Ulauncher/issues">Issue Tracker</a></li>


### PR DESCRIPTION
Looks like docs are already built and hosted at https://docs.ulauncher.io

I'd like to add the link up in the nav bar of the site.