### PR TITLE
fix: ubuntu installation instructions

### DIFF
--- a/assets/js/releases.js
+++ b/assets/js/releases.js
@@ -63,7 +63,7 @@ jQuery(function($) {
             $('#aur-shell').html(aurShell);
 
             var launchpadPackage = selectStable ? 'ulauncher' : 'ulauncher-dev';
-            $('#ubuntu-ppa').html('<code>sudo add-apt-repository ppa:agornostal/' + launchpadPackage + ' && sudo apt update && sudo apt install ulauncher</code>');
+            $('#ubuntu-ppa').html('<code>sudo add-apt-repository universe -y && sudo add-apt-repository ppa:agornostal/' + launchpadPackage + ' -y && sudo apt update && sudo apt install ulauncher</code>');
 
             var debianInstructions = 'sudo apt update && sudo apt install -y gnupg\n' +
                 'gpg --keyserver keyserver.ubuntu.com --recv 0xfaf1020699503176\n' +


### PR DESCRIPTION
`python3-levenshtein` and `gir1.2-ayatanaappindicator3-0.1` are in `universe`, so you have to enable that to install ulauncher (`sudo add-apt-repository universe`).

Also added the -y flag for silent (no confirmation).