### PR TITLE
support v-prefix in github tag/release version

### DIFF
--- a/assets/js/releases.js
+++ b/assets/js/releases.js
@@ -24,6 +24,12 @@ jQuery(function($) {
         }
         const stableVer = stable.name || stable.tag_name;
         const devVer = dev.name || dev.tag_name;
+        if (stableVer.charAt(0) !== "v"){
+            stableVer = `v${stableVer}`
+        }
+        if (devVer.charAt(0) !== "v"){
+            devVer = `v${devVer}`
+        }
 
         var stableSelected = getDefaultReleaseOption() == 'stable';
 
@@ -38,10 +44,10 @@ jQuery(function($) {
                 .addClass(!selectStable ? 'fa-dot-circle' : 'fa-circle');
 
             $('#stable-release + .option-info')
-                .html('<b>v' + stableVer + '</b> from ' + new Date(stable.published_at).toLocaleDateString() +
+                .html('<b>' + stableVer + '</b> from ' + new Date(stable.published_at).toLocaleDateString() +
                     ' <a href="' + stable.html_url + '">Release notes</a>.');
             $('#dev-release + .option-info')
-                .html('<b>v' + devVer + '</b> from ' + new Date(dev.published_at).toLocaleDateString() +
+                .html('<b>' + devVer + '</b> from ' + new Date(dev.published_at).toLocaleDateString() +
                     ' <a href="' + dev.html_url + '">Release notes</a>.');
 
             var aurLink = selectStable ? 'https://aur.archlinux.org/packages/ulauncher/' :


### PR DESCRIPTION
I started using these for v6 since it's pretty much the standard, but now it looks like this

![image](https://github.com/Ulauncher/ulauncher.io/assets/515120/389dbcfb-f415-46c5-a231-f17d6efc2841)
